### PR TITLE
Fixed wrong RuntimeException namespace

### DIFF
--- a/src/randomorg/Client.php
+++ b/src/randomorg/Client.php
@@ -114,11 +114,11 @@ class Client implements ClientInterface
         $responseCode = curl_getinfo($this->ch, CURLINFO_HTTP_CODE);
 
         if (curl_errno($this->ch)) {
-            throw new RuntimeException(curl_error($this->ch));
+            throw new \RuntimeException(curl_error($this->ch));
         }
 
         if ($responseCode === 401 || $responseCode === 403) {
-            throw new RuntimeException('Access denied');
+            throw new \RuntimeException('Access denied');
         }
 
         $response = json_decode($responseBody, true);


### PR DESCRIPTION
now when trying to throw exception at lines 117 and 119 in `src/randomorg/Client.php` you get
`Symfony\Component\Debug\Exception\FatalThrowableError  : Class 'RandomOrg\RuntimeException' not found`

this pr fixes this issue